### PR TITLE
YEL-38 [update] Soft delete 처리를 위한 User 엔티티 수정

### DIFF
--- a/src/main/java/com/yello/server/domain/user/entity/User.java
+++ b/src/main/java/com/yello/server/domain/user/entity/User.java
@@ -18,10 +18,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE user SET deletedAt = NOW() WHERE id = ?")
+@Where(clause = "deletedAt IS NULL")
 public class User extends AuditingTimeEntity {
 
     @Id


### PR DESCRIPTION
### ☘️ Related Issue
* resolves YEL-38

### ✅ Work description
* Soft Delete 처리를 위하여 User 엔티티 클래스에 삭제 처리(SQLDelete)와 조건(Where) 추가

### 💡 PR point
* 
