### PR TITLE
YEL-21 [feat] 내 친구 전체 조회 API 구현

### DIFF
--- a/src/main/java/com/yello/server/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/yello/server/domain/friend/controller/FriendController.java
@@ -1,41 +1,64 @@
 package com.yello.server.domain.friend.controller;
 
-import com.yello.server.domain.friend.service.FriendServiceImpl;
+import static com.yello.server.global.common.SuccessCode.ADD_FRIEND_SUCCESS;
+import static com.yello.server.global.common.SuccessCode.READ_FRIEND_SUCCESS;
+import static com.yello.server.global.common.util.PaginationUtil.createPageable;
+
+import com.yello.server.domain.friend.dto.FriendsResponse;
+import com.yello.server.domain.friend.service.FriendService;
 import com.yello.server.global.common.dto.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import javax.validation.Valid;
-
-import static com.yello.server.global.common.SuccessCode.ADD_FRIEND_SUCCESS;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "02. Friend")
 @RestController
 @RequestMapping("/api/v1/friend")
 @RequiredArgsConstructor
 public class FriendController {
-    private final FriendServiceImpl friendService;
+
+    private final FriendService friendService;
 
     @Operation(summary = "친구 추가하기 API", responses = {
-            @ApiResponse(
-                    responseCode = "200",
-                    content = @Content(mediaType = "application/json")
-            )
+        @ApiResponse(
+            responseCode = "200",
+            content = @Content(mediaType = "application/json")
+        )
     })
-    @PostMapping("/{friendId}")
+    @PostMapping("/{targetId}")
     public ResponseEntity<BaseResponse> addFriend(
-            @Parameter(name = "friendId", description = "친구 아이디 입니다.")
-            @Valid @PathVariable Long friendId,
-            @RequestHeader("user-id") @Valid Long userId
-    ) {
-
-        friendService.addFriend(userId, friendId);
+        @Parameter(name = "targetId", description = "친구 신청할 상대 유저의 아이디 값 입니다.")
+        @Valid @PathVariable Long targetId,
+        @RequestHeader("user-id") @Valid Long userId) {
+        friendService.addFriend(userId, targetId);
         return ResponseEntity.ok(BaseResponse.success(ADD_FRIEND_SUCCESS));
+    }
+
+    @Operation(summary = "내 친구 전체 조회 API", responses = {
+        @ApiResponse(
+            responseCode = "200",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = FriendsResponse.class))
+        )
+    })
+    @GetMapping
+    public ResponseEntity<BaseResponse> findAllFriend(
+        @Parameter(name = "page", description = "페이지네이션 페이지 번호입니다.", example = "1")
+        @Valid @RequestParam Integer page,
+        @RequestHeader("user-id") @Valid Long userId) {
+        friendService.findAllFriends(createPageable(page), userId);
+        return ResponseEntity.ok(BaseResponse.success(READ_FRIEND_SUCCESS));
     }
 }

--- a/src/main/java/com/yello/server/domain/friend/dto/FriendResponse.java
+++ b/src/main/java/com/yello/server/domain/friend/dto/FriendResponse.java
@@ -1,0 +1,22 @@
+package com.yello.server.domain.friend.dto;
+
+import com.yello.server.domain.friend.entity.Friend;
+import lombok.Builder;
+
+@Builder
+public record FriendResponse(
+    Long userId,
+    String friendName,
+    String friendProfileImage,
+    String friendGroup
+) {
+
+    public static FriendResponse of(Friend friend) {
+        return FriendResponse.builder()
+            .userId(friend.getId())
+            .friendName(friend.getTarget().getName())
+            .friendProfileImage(friend.getTarget().getProfileImage())
+            .friendGroup(friend.getTarget().getGroup().toString())
+            .build();
+    }
+}

--- a/src/main/java/com/yello/server/domain/friend/dto/FriendsResponse.java
+++ b/src/main/java/com/yello/server/domain/friend/dto/FriendsResponse.java
@@ -1,0 +1,21 @@
+package com.yello.server.domain.friend.dto;
+
+import com.yello.server.domain.friend.entity.Friend;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record FriendsResponse(
+    Integer totalCount,
+    List<FriendResponse> friends
+) {
+
+    public static FriendsResponse of(List<Friend> friends) {
+        return FriendsResponse.builder()
+            .totalCount(friends.size())
+            .friends(friends.stream()
+                .map(FriendResponse::of)
+                .toList())
+            .build();
+    }
+}

--- a/src/main/java/com/yello/server/domain/friend/entity/Friend.java
+++ b/src/main/java/com/yello/server/domain/friend/entity/Friend.java
@@ -2,36 +2,42 @@ package com.yello.server.domain.friend.entity;
 
 import com.yello.server.domain.user.entity.User;
 import com.yello.server.global.common.dto.AuditingTimeEntity;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
-
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Friend extends AuditingTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "followerId")
-    private User follower;
+    @JoinColumn(name = "user")
+    private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "followingId")
-    private User following;
+    @JoinColumn(name = "target")
+    private User target;
 
     @Builder
-    public Friend(User follower, User following) {
-        this.follower = follower;
-        this.following = following;
+    public Friend(User user, User target) {
+        this.user = user;
+        this.target = target;
     }
 
-    public static Friend newFriend(User follower, User following) {
-        return new Friend(follower, following);
+    public static Friend createFriend(User user, User target) {
+        return new Friend(user, target);
     }
 }

--- a/src/main/java/com/yello/server/domain/friend/entity/FriendRepository.java
+++ b/src/main/java/com/yello/server/domain/friend/entity/FriendRepository.java
@@ -1,11 +1,16 @@
 package com.yello.server.domain.friend.entity;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface FriendRepository extends JpaRepository<Friend, Long> {
 
-    @Query("select f from Friend f where f.follower.id = :friendId and f.following.id = :userId")
-    Friend findByFollowingAndFollower(@Param("userId") Long userId, @Param("friendId") Long friendId);
+    @Query("select f from Friend f where f.target.id = :targetId and f.user.id = :userId")
+    Friend findByFollowingAndFollower(@Param("userId") Long userId, @Param("targetId") Long targetId);
+
+    @Query("select f from Friend f where f.user.id = :userId")
+    Page<Friend> findAllFriendsByUserId(Pageable pageable, @Param("userId") Long userId);
 }

--- a/src/main/java/com/yello/server/domain/friend/service/FriendService.java
+++ b/src/main/java/com/yello/server/domain/friend/service/FriendService.java
@@ -1,7 +1,11 @@
 package com.yello.server.domain.friend.service;
 
-import org.springframework.transaction.annotation.Transactional;
+import com.yello.server.domain.friend.dto.FriendsResponse;
+import org.springframework.data.domain.Pageable;
 
 public interface FriendService {
-    void addFriend(Long userId, Long friendId);
+
+    FriendsResponse findAllFriends(Pageable pageable, Long userId);
+
+    void addFriend(Long userId, Long targetId);
 }

--- a/src/main/java/com/yello/server/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/com/yello/server/domain/friend/service/FriendServiceImpl.java
@@ -1,33 +1,47 @@
 package com.yello.server.domain.friend.service;
 
+import com.yello.server.domain.friend.dto.FriendsResponse;
 import com.yello.server.domain.friend.entity.Friend;
 import com.yello.server.domain.friend.entity.FriendRepository;
 import com.yello.server.domain.user.entity.User;
 import com.yello.server.domain.user.entity.UserRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class FriendServiceImpl implements FriendService {
 
     private final FriendRepository friendRepository;
     private final UserRepository userRepository;
 
+    @Override
+    public FriendsResponse findAllFriends(Pageable pageable, Long userId) {
+        List<Friend> friends = friendRepository.findAllFriendsByUserId(pageable, userId)
+            .stream()
+            .toList();
+
+        return FriendsResponse.of(friends);
+    }
+
     @Transactional
     @Override
-    public void addFriend(Long userId, Long friendId) {
+    public void addFriend(Long userId, Long targetId) {
 
-        User friend = userRepository.findById(friendId).get(); // orElse 처리하기
+        User target = userRepository.findById(targetId).get(); // orElse 처리하기
         User user = userRepository.findById(userId).get();
 
-        Friend friendData = friendRepository.findByFollowingAndFollower(userId, friendId);
+        Friend friendData = friendRepository.findByFollowingAndFollower(userId, targetId);
 
-        if (friendData != null) {
+        if (friendData!=null) {
             return;
         }
 
-        friendRepository.save(Friend.newFriend(friend, user));
+        friendRepository.save(Friend.createFriend(user, target));
+        friendRepository.save(Friend.createFriend(target, user));
     }
 }

--- a/src/main/java/com/yello/server/domain/group/entity/School.java
+++ b/src/main/java/com/yello/server/domain/group/entity/School.java
@@ -1,16 +1,20 @@
 package com.yello.server.domain.group.entity;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
-
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class School {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -29,5 +33,10 @@ public class School {
         this.schoolName = schoolName;
         this.departmentName = departmentName;
         this.admissionYear = admissionYear;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s %s %d학번", schoolName, departmentName, admissionYear);
     }
 }

--- a/src/main/java/com/yello/server/domain/vote/controller/VoteController.java
+++ b/src/main/java/com/yello/server/domain/vote/controller/VoteController.java
@@ -1,7 +1,7 @@
 package com.yello.server.domain.vote.controller;
 
 import static com.yello.server.global.common.SuccessCode.READ_VOTE_SUCCESS;
-import static com.yello.server.global.common.util.ConstantUtil.PAGE_LIMIT;
+import static com.yello.server.global.common.util.PaginationUtil.createPageable;
 
 import com.yello.server.domain.vote.dto.response.VoteDetailResponse;
 import com.yello.server.domain.vote.dto.response.VoteResponse;
@@ -16,8 +16,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -42,8 +40,7 @@ public class VoteController {
     public ResponseEntity<BaseResponse> findAllMyVotes(
         @Parameter(name = "page", description = "페이지네이션 페이지 번호입니다.", example = "1")
         @RequestParam Integer page) {
-        Pageable pageable = PageRequest.of(page, PAGE_LIMIT);
-        val data = voteService.findAllVotes(pageable);
+        val data = voteService.findAllVotes(createPageable(page));
         return ResponseEntity.ok(BaseResponse.success(READ_VOTE_SUCCESS, data));
     }
 

--- a/src/main/java/com/yello/server/global/common/SuccessCode.java
+++ b/src/main/java/com/yello/server/global/common/SuccessCode.java
@@ -12,6 +12,7 @@ public enum SuccessCode {
      * 200 OK
      */
     READ_VOTE_SUCCESS(HttpStatus.OK, "투표 조회에 성공했습니다."),
+    READ_FRIEND_SUCCESS(HttpStatus.OK, "친구 조회에 성공했습니다."),
     ADD_FRIEND_SUCCESS(HttpStatus.OK, "친구 추가에 성공했습니다."),
 
     /**

--- a/src/main/java/com/yello/server/global/common/util/PaginationUtil.java
+++ b/src/main/java/com/yello/server/global/common/util/PaginationUtil.java
@@ -1,0 +1,13 @@
+package com.yello.server.global.common.util;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+public class PaginationUtil {
+
+    private static final int PAGE_LIMIT = 10;
+
+    public static Pageable createPageable(Integer page) {
+        return PageRequest.of(page, PAGE_LIMIT);
+    }
+}

--- a/src/test/java/com/yello/server/friend/FriendControllerTest.java
+++ b/src/test/java/com/yello/server/friend/FriendControllerTest.java
@@ -1,5 +1,7 @@
 package com.yello.server.friend;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.yello.server.domain.friend.entity.Friend;
 import com.yello.server.domain.friend.entity.FriendRepository;
 import com.yello.server.domain.group.entity.School;
@@ -8,13 +10,15 @@ import com.yello.server.domain.user.entity.Gender;
 import com.yello.server.domain.user.entity.Social;
 import com.yello.server.domain.user.entity.User;
 import com.yello.server.domain.user.entity.UserRepository;
-import org.assertj.core.api.Assertions;
+import com.yello.server.global.common.util.PaginationUtil;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
 
 
 @SpringBootTest
@@ -29,19 +33,46 @@ class FriendControllerTest {
     SchoolRepository schoolRepository;
 
     @Test
-    public void addFriendTest() {
+    @DisplayName("친구 생성에 성공합니다.")
+    void addFriendTest() {
         //given
         School group = schoolRepository.save(new School("솝트", "서버", 32));
-        User user = userRepository.save(new User(1L, "현정", "hj_p", Gender.FEMALE, 0, Social.KAKAO, "D", "dd", LocalDateTime.now(), group));
-        User friend = userRepository.save(new User(2L, "세훈", "훈세", Gender.MALE, 0, Social.KAKAO, "D", "dd", LocalDateTime.now(), group));
+        User user = createNewUser(1L, "현정", "hj_p", Gender.FEMALE, group);
+        User target = createNewUser(2L, "세훈", "훈세", Gender.MALE, group);
 
         //when
-        Friend follow = friendRepository.save(Friend.newFriend(friend, user));
+        Friend follow = friendRepository.save(Friend.createFriend(user, target));
 
         //then
-        Assertions.assertThat(friend.getName()).isEqualTo(follow.getFollower().getName());
-        Assertions.assertThat(user.getName()).isEqualTo(follow.getFollowing().getName());
-
+        assertThat(target.getName()).isEqualTo(follow.getTarget().getName());
+        assertThat(user.getName()).isEqualTo(follow.getUser().getName());
     }
 
+    @Test
+    @DisplayName("내 친구 전체 조회에 성공합니다.")
+    void findAllMyFriendTest() {
+        // given
+        Pageable pageable = PaginationUtil.createPageable(0);
+        School group = schoolRepository.save(new School("솝트", "서버", 32));
+        User user = createNewUser(1L, "현정", "hj_p", Gender.FEMALE, group);
+        User friendA = createNewUser(2L, "세훈", "훈세", Gender.MALE, group);
+        User friendB = createNewUser(3L, "의제", "제의", Gender.MALE, group);
+
+        // when
+        friendRepository.save(Friend.createFriend(user, friendA));
+        friendRepository.save(Friend.createFriend(user, friendB));
+
+        List<Friend> friends = friendRepository.findAllFriendsByUserId(pageable, user.getId())
+            .stream()
+            .toList();
+
+        // then
+        assertThat(friends.size()).isEqualTo(2);
+    }
+
+    private User createNewUser(Long id, String name, String yelloId, Gender gender, School group) {
+        return userRepository.save(
+            new User(id, name, yelloId, gender, 0, Social.KAKAO, "profileImageUrl", "uuid", LocalDateTime.now(),
+                group));
+    }
 }


### PR DESCRIPTION
### ☘️ Related Issue
* resolves YEL-21

### ✅ Work description
* 내 친구 전체 조회 API 구현
* Pageable 객체 생성 코드가 중복되어 유틸 클래스 선언
* Friend 엔티티에서 following, follower 필드명이 애매하여 user, target으로 정정
* 테스트 코드 추가
* 친구 신청 시, 쌍방 친구 연결을 위하여 친구 추가 부분 로직 수정

### 💡 PR point
* 
