### PR TITLE
YEL-19 [feat] 유저 상세 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/yello/server/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/yello/server/domain/friend/controller/FriendController.java
@@ -1,5 +1,9 @@
 package com.yello.server.domain.friend.controller;
 
+import static com.yello.server.global.common.SuccessCode.ADD_FRIEND_SUCCESS;
+import static com.yello.server.global.common.SuccessCode.READ_FRIEND_SUCCESS;
+import static com.yello.server.global.common.util.PaginationUtil.createPageable;
+
 import com.yello.server.domain.friend.dto.FriendsResponse;
 import com.yello.server.domain.friend.dto.response.FriendShuffleResponse;
 import com.yello.server.domain.friend.service.FriendService;
@@ -11,16 +15,17 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import javax.validation.Valid;
 import java.util.List;
-
-import static com.yello.server.global.common.SuccessCode.ADD_FRIEND_SUCCESS;
-import static com.yello.server.global.common.SuccessCode.READ_FRIEND_SUCCESS;
-import static com.yello.server.global.common.util.PaginationUtil.createPageable;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "02. Friend")
 @RestController
@@ -31,44 +36,44 @@ public class FriendController {
     private final FriendService friendService;
 
     @Operation(summary = "친구 추가하기 API", responses = {
-            @ApiResponse(
-                    responseCode = "200",
-                    content = @Content(mediaType = "application/json")
-            )
+        @ApiResponse(
+            responseCode = "200",
+            content = @Content(mediaType = "application/json")
+        )
     })
     @PostMapping("/{targetId}")
     public BaseResponse addFriend(
-            @Parameter(name = "targetId", description = "친구 신청할 상대 유저의 아이디 값 입니다.")
-            @Valid @PathVariable Long targetId,
-            @RequestHeader("user-id") @Valid Long userId) {
+        @Parameter(name = "targetId", description = "친구 신청할 상대 유저의 아이디 값 입니다.")
+        @Valid @PathVariable Long targetId,
+        @RequestHeader("user-id") @Valid Long userId) {
         friendService.addFriend(userId, targetId);
         return BaseResponse.success(ADD_FRIEND_SUCCESS);
     }
 
     @Operation(summary = "내 친구 전체 조회 API", responses = {
-            @ApiResponse(
-                    responseCode = "200",
-                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = FriendsResponse.class))
-            )
+        @ApiResponse(
+            responseCode = "200",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = FriendsResponse.class))
+        )
     })
     @GetMapping
-    public ResponseEntity<BaseResponse> findAllFriend(
-            @Parameter(name = "page", description = "페이지네이션 페이지 번호입니다.", example = "1")
-            @Valid @RequestParam Integer page,
-            @RequestHeader("user-id") @Valid Long userId) {
-        friendService.findAllFriends(createPageable(page), userId);
-        return ResponseEntity.ok(BaseResponse.success(READ_FRIEND_SUCCESS));
+    public BaseResponse<FriendsResponse> findAllFriend(
+        @Parameter(name = "page", description = "페이지네이션 페이지 번호입니다.", example = "1")
+        @Valid @RequestParam Integer page,
+        @RequestHeader("user-id") @Valid Long userId) {
+        val data = friendService.findAllFriends(createPageable(page), userId);
+        return BaseResponse.success(READ_FRIEND_SUCCESS, data);
     }
 
     @Operation(summary = "친구 셔플 조회 API", responses = {
-            @ApiResponse(
-                    responseCode = "200",
-                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = FriendShuffleResponse.class))
-            )
+        @ApiResponse(
+            responseCode = "200",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = FriendShuffleResponse.class))
+        )
     })
     @GetMapping("/shuffle")
     public BaseResponse<List<FriendShuffleResponse>> shuffleFriend(
-            @RequestHeader("user-id") @Valid Long userId) {
+        @RequestHeader("user-id") @Valid Long userId) {
         List<FriendShuffleResponse> friendShuffleResponse = friendService.shuffleFriend(userId);
 
         return BaseResponse.success(SuccessCode.SHUFFLE_FRIEND_SUCCESS, friendShuffleResponse);

--- a/src/main/java/com/yello/server/domain/friend/entity/FriendRepository.java
+++ b/src/main/java/com/yello/server/domain/friend/entity/FriendRepository.java
@@ -1,13 +1,12 @@
 package com.yello.server.domain.friend.entity;
 
 import com.yello.server.domain.user.entity.User;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 
 public interface FriendRepository extends JpaRepository<Friend, Long> {
 

--- a/src/main/java/com/yello/server/domain/friend/exception/FriendException.java
+++ b/src/main/java/com/yello/server/domain/friend/exception/FriendException.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 
 @Getter
 public class FriendException extends CustomException {
-    public FriendException(ErrorCode error, String message) {
-        super(error, "[FriendException] " + message);
+
+    public FriendException(ErrorCode error) {
+        super(error, "[FriendException] " + error.getMessage());
     }
 }

--- a/src/main/java/com/yello/server/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/com/yello/server/domain/friend/service/FriendServiceImpl.java
@@ -1,5 +1,7 @@
 package com.yello.server.domain.friend.service;
 
+import static com.yello.server.global.common.util.ConstantUtil.RANDOM_COUNT;
+
 import com.yello.server.domain.friend.dto.FriendsResponse;
 import com.yello.server.domain.friend.dto.response.FriendShuffleResponse;
 import com.yello.server.domain.friend.entity.Friend;
@@ -9,17 +11,13 @@ import com.yello.server.domain.user.entity.User;
 import com.yello.server.domain.user.entity.UserRepository;
 import com.yello.server.domain.user.exception.UserException;
 import com.yello.server.global.common.ErrorCode;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static com.yello.server.global.common.util.ConstantUtil.RANDOM_COUNT;
 
 @Service
 @RequiredArgsConstructor
@@ -32,8 +30,8 @@ public class FriendServiceImpl implements FriendService {
     @Override
     public FriendsResponse findAllFriends(Pageable pageable, Long userId) {
         List<Friend> friends = friendRepository.findAllFriendsByUserId(pageable, userId)
-                .stream()
-                .toList();
+            .stream()
+            .toList();
 
         return FriendsResponse.of(friends);
     }
@@ -42,13 +40,15 @@ public class FriendServiceImpl implements FriendService {
     @Override
     public void addFriend(Long userId, Long targetId) {
 
-        User target = userRepository.findById(targetId).orElseThrow(() -> new UserException(ErrorCode.NOT_FOUND_USER_EXCEPTION, ErrorCode.NOT_FOUND_USER_EXCEPTION.getMessage()));
-        User user = userRepository.findById(userId).orElseThrow(() -> new UserException(ErrorCode.NOT_FOUND_USER_EXCEPTION, ErrorCode.NOT_FOUND_USER_EXCEPTION.getMessage()));
+        User target = userRepository.findById(targetId)
+            .orElseThrow(() -> new UserException(ErrorCode.NOT_FOUND_USER_EXCEPTION));
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new UserException(ErrorCode.NOT_FOUND_USER_EXCEPTION));
 
         Friend friendData = friendRepository.findByFollowingAndFollower(userId, targetId);
 
-        if (friendData != null) {
-            throw new FriendException(ErrorCode.EXIST_FRIEND_EXCEPTION, ErrorCode.EXIST_FRIEND_EXCEPTION.getMessage());
+        if (friendData!=null) {
+            throw new FriendException(ErrorCode.EXIST_FRIEND_EXCEPTION);
         }
 
         friendRepository.save(Friend.createFriend(user, target));
@@ -59,22 +59,19 @@ public class FriendServiceImpl implements FriendService {
     public List<FriendShuffleResponse> shuffleFriend(Long userId) {
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(
-                        ErrorCode.NOT_FOUND_USER_EXCEPTION,
-                        ErrorCode.NOT_FOUND_USER_EXCEPTION.getMessage()
-                ));
+            .orElseThrow(() -> new UserException(ErrorCode.NOT_FOUND_USER_EXCEPTION));
 
         List<Friend> allFriends = friendRepository.findAllByUser(user);
 
         if (allFriends.size() < RANDOM_COUNT) {
-            throw new FriendException(ErrorCode.FRIEND_COUNT_LACK_EXCEPTION, ErrorCode.FRIEND_COUNT_LACK_EXCEPTION.getMessage());
+            throw new FriendException(ErrorCode.FRIEND_COUNT_LACK_EXCEPTION);
         }
 
         Collections.shuffle(allFriends);
 
         return allFriends.stream()
-                .map(FriendShuffleResponse::of)
-                .limit(RANDOM_COUNT)
-                .collect(Collectors.toList());
+            .map(FriendShuffleResponse::of)
+            .limit(RANDOM_COUNT)
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/yello/server/domain/user/controller/UserController.java
+++ b/src/main/java/com/yello/server/domain/user/controller/UserController.java
@@ -1,6 +1,18 @@
 package com.yello.server.domain.user.controller;
 
+import static com.yello.server.global.common.SuccessCode.READ_USER_SUCCESS;
+
+import com.yello.server.domain.user.dto.UserResponse;
+import com.yello.server.domain.user.service.UserService;
+import com.yello.server.global.common.dto.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,4 +21,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/user")
 public class UserController {
 
+    private final UserService userService;
+
+    @Operation(summary = "유저 정보 조회 API", responses = {
+        @ApiResponse(
+            responseCode = "200",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserResponse.class))),
+    })
+    @GetMapping("/{userId}")
+    public BaseResponse<UserResponse> findUser(@PathVariable Long userId) {
+        val data = userService.findUser(userId);
+        return BaseResponse.success(READ_USER_SUCCESS, data);
+    }
 }

--- a/src/main/java/com/yello/server/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/yello/server/domain/user/dto/UserResponse.java
@@ -1,0 +1,26 @@
+package com.yello.server.domain.user.dto;
+
+import com.yello.server.domain.user.entity.User;
+import lombok.Builder;
+
+@Builder
+public record UserResponse(
+    String name,
+    String group,
+    String yelloId,
+    Integer yelloCount,
+    Integer friendCount,
+    Integer point
+) {
+
+    public static UserResponse of(User user, Integer yelloCount, Integer friendCount) {
+        return UserResponse.builder()
+            .name(user.getName())
+            .group(user.getGroup().toString())
+            .yelloId(user.getYelloId())
+            .yelloCount(yelloCount)
+            .friendCount(friendCount)
+            .point(user.getPoint())
+            .build();
+    }
+}

--- a/src/main/java/com/yello/server/domain/user/entity/User.java
+++ b/src/main/java/com/yello/server/domain/user/entity/User.java
@@ -3,8 +3,15 @@ package com.yello.server.domain.user.entity;
 import com.yello.server.domain.group.entity.School;
 import com.yello.server.global.common.dto.AuditingTimeEntity;
 import java.time.LocalDateTime;
-import javax.persistence.*;
-
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,8 +23,8 @@ import org.hibernate.annotations.Where;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE user SET deletedAt = NOW() WHERE id = ?")
-@Where(clause = "deletedAt IS NULL")
+@SQLDelete(sql = "UPDATE user SET deleted_at = NOW() WHERE id = ?")
+@Where(clause = "deleted_at IS NULL")
 public class User extends AuditingTimeEntity {
 
     @Id

--- a/src/main/java/com/yello/server/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/yello/server/domain/user/exception/UserNotFoundException.java
@@ -5,9 +5,9 @@ import com.yello.server.global.exception.CustomException;
 import lombok.Getter;
 
 @Getter
-public class UserException extends CustomException {
+public class UserNotFoundException extends CustomException {
 
-    public UserException(ErrorCode error) {
-        super(error, "[UserException] " + error.getMessage());
+    public UserNotFoundException(ErrorCode error) {
+        super(error, "[UserNotFoundException] " + error.getMessage());
     }
 }

--- a/src/main/java/com/yello/server/domain/user/service/UserService.java
+++ b/src/main/java/com/yello/server/domain/user/service/UserService.java
@@ -1,10 +1,10 @@
 package com.yello.server.domain.user.service;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import com.yello.server.domain.user.dto.UserResponse;
 
-@Service
-@RequiredArgsConstructor
-public class UserService {
+public interface UserService {
 
+    UserResponse findUser(Long userId);
 }
+
+

--- a/src/main/java/com/yello/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/yello/server/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,35 @@
+package com.yello.server.domain.user.service;
+
+import static com.yello.server.global.common.ErrorCode.NOT_FOUND_USER_EXCEPTION;
+
+import com.yello.server.domain.friend.entity.FriendRepository;
+import com.yello.server.domain.user.dto.UserResponse;
+import com.yello.server.domain.user.entity.User;
+import com.yello.server.domain.user.entity.UserRepository;
+import com.yello.server.domain.user.exception.UserNotFoundException;
+import com.yello.server.domain.vote.entity.VoteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final FriendRepository friendRepository;
+    private final VoteRepository voteRepository;
+
+    @Override
+    public UserResponse findUser(Long userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new UserNotFoundException(NOT_FOUND_USER_EXCEPTION));
+        Integer friendCount = friendRepository.findAllByUser(user)
+            .size();
+        Integer yelloCount = voteRepository.findAllByReceiverUserId(user.getId())
+            .size();
+
+        return UserResponse.of(user, friendCount, yelloCount);
+    }
+}

--- a/src/main/java/com/yello/server/domain/vote/controller/VoteController.java
+++ b/src/main/java/com/yello/server/domain/vote/controller/VoteController.java
@@ -14,9 +14,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -37,11 +37,11 @@ public class VoteController {
             content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = VoteResponse.class)))),
     })
     @GetMapping
-    public ResponseEntity<BaseResponse> findAllMyVotes(
+    public BaseResponse<List<VoteResponse>> findAllMyVotes(
         @Parameter(name = "page", description = "페이지네이션 페이지 번호입니다.", example = "1")
         @RequestParam Integer page) {
         val data = voteService.findAllVotes(createPageable(page));
-        return ResponseEntity.ok(BaseResponse.success(READ_VOTE_SUCCESS, data));
+        return BaseResponse.success(READ_VOTE_SUCCESS, data);
     }
 
     @Operation(summary = "투표 상세 조회 API", responses = {
@@ -50,8 +50,8 @@ public class VoteController {
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = VoteDetailResponse.class))),
     })
     @GetMapping("/{voteId}")
-    public ResponseEntity<BaseResponse> findVote(@PathVariable Long voteId) {
+    public BaseResponse<VoteDetailResponse> findVote(@PathVariable Long voteId) {
         val data = voteService.findVoteById(voteId);
-        return ResponseEntity.ok(BaseResponse.success(READ_VOTE_SUCCESS, data));
+        return BaseResponse.success(READ_VOTE_SUCCESS, data);
     }
 }

--- a/src/main/java/com/yello/server/domain/vote/entity/VoteRepository.java
+++ b/src/main/java/com/yello/server/domain/vote/entity/VoteRepository.java
@@ -1,7 +1,13 @@
 package com.yello.server.domain.vote.entity;
 
+import com.yello.server.domain.friend.entity.Friend;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface VoteRepository extends JpaRepository<Vote, Long> {
 
+    @Query("select v from Vote v where v.receiver.id = :userId")
+    List<Friend> findAllByReceiverUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/yello/server/domain/vote/exception/VoteNotFoundException.java
+++ b/src/main/java/com/yello/server/domain/vote/exception/VoteNotFoundException.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 public class VoteException extends CustomException {
 
-    public VoteException(ErrorCode error, String message) {
-        super(error, "[VoteException] " + message);
+    public VoteException(ErrorCode error) {
+        super(error, "[VoteException] " + error.getMessage());
     }
 }

--- a/src/main/java/com/yello/server/domain/vote/exception/VoteNotFoundException.java
+++ b/src/main/java/com/yello/server/domain/vote/exception/VoteNotFoundException.java
@@ -5,9 +5,9 @@ import com.yello.server.global.exception.CustomException;
 import lombok.Getter;
 
 @Getter
-public class VoteException extends CustomException {
+public class VoteNotFoundException extends CustomException {
 
-    public VoteException(ErrorCode error) {
-        super(error, "[VoteException] " + error.getMessage());
+    public VoteNotFoundException(ErrorCode error) {
+        super(error, "[VoteNotFoundException] " + error.getMessage());
     }
 }

--- a/src/main/java/com/yello/server/domain/vote/service/VoteServiceImpl.java
+++ b/src/main/java/com/yello/server/domain/vote/service/VoteServiceImpl.java
@@ -7,7 +7,7 @@ import com.yello.server.domain.vote.dto.response.VoteFriendResponse;
 import com.yello.server.domain.vote.dto.response.VoteResponse;
 import com.yello.server.domain.vote.entity.Vote;
 import com.yello.server.domain.vote.entity.VoteRepository;
-import com.yello.server.domain.vote.exception.VoteException;
+import com.yello.server.domain.vote.exception.VoteNotFoundException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -44,9 +44,6 @@ public class VoteServiceImpl implements VoteService {
 
     private Vote findVote(Long id) {
         return voteRepository.findById(id)
-            .orElseThrow(() -> new VoteException(
-                NOT_FOUND_VOTE_EXCEPTION,
-                NOT_FOUND_VOTE_EXCEPTION.getMessage())
-            );
+            .orElseThrow(() -> new VoteNotFoundException(NOT_FOUND_VOTE_EXCEPTION));
     }
 }

--- a/src/main/java/com/yello/server/global/common/ControllerExceptionAdvice.java
+++ b/src/main/java/com/yello/server/global/common/ControllerExceptionAdvice.java
@@ -2,7 +2,8 @@ package com.yello.server.global.common;
 
 import com.yello.server.domain.friend.exception.FriendException;
 import com.yello.server.domain.user.exception.UserException;
-import com.yello.server.domain.vote.exception.VoteException;
+import com.yello.server.domain.user.exception.UserNotFoundException;
+import com.yello.server.domain.vote.exception.VoteNotFoundException;
 import com.yello.server.global.common.dto.BaseResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,24 +14,30 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class ControllerExceptionAdvice {
 
     //vote
-    @ExceptionHandler(VoteException.class)
-    public ResponseEntity<BaseResponse> VoteException(VoteException e) {
+    @ExceptionHandler(VoteNotFoundException.class)
+    public ResponseEntity<BaseResponse> VoteException(VoteNotFoundException exception) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-            .body(BaseResponse.error(e.getError(), e.getMessage()));
+            .body(BaseResponse.error(exception.getError(), exception.getMessage()));
     }
 
     // user
     @ExceptionHandler(UserException.class)
-    public ResponseEntity<BaseResponse> UserException(UserException e) {
+    public ResponseEntity<BaseResponse> UserException(UserException exception) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(BaseResponse.error(exception.getError(), exception.getMessage()));
+    }
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<BaseResponse> UserNotFoundException(UserNotFoundException exception) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(BaseResponse.error(e.getError(), e.getMessage()));
+            .body(BaseResponse.error(exception.getError(), exception.getMessage()));
     }
 
     // friend
     @ExceptionHandler(FriendException.class)
-    public ResponseEntity<BaseResponse> FriendException(FriendException e) {
+    public ResponseEntity<BaseResponse> FriendException(FriendException exception) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(BaseResponse.error(e.getError(), e.getMessage()));
+            .body(BaseResponse.error(exception.getError(), exception.getMessage()));
     }
 
 }

--- a/src/main/java/com/yello/server/global/common/SuccessCode.java
+++ b/src/main/java/com/yello/server/global/common/SuccessCode.java
@@ -13,6 +13,7 @@ public enum SuccessCode {
      */
     READ_VOTE_SUCCESS(HttpStatus.OK, "투표 조회에 성공했습니다."),
     READ_FRIEND_SUCCESS(HttpStatus.OK, "친구 조회에 성공했습니다."),
+    READ_USER_SUCCESS(HttpStatus.OK, "유저 조회에 성공했습니다."),
     ADD_FRIEND_SUCCESS(HttpStatus.OK, "친구 추가에 성공했습니다."),
     SHUFFLE_FRIEND_SUCCESS(HttpStatus.OK, "친구 셔플에 성공했습니다."),
 

--- a/src/test/java/com/yello/server/integration/friend/FriendControllerTest.java
+++ b/src/test/java/com/yello/server/integration/friend/FriendControllerTest.java
@@ -1,4 +1,6 @@
-package com.yello.server.friend;
+package com.yello.server.integration.friend;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.yello.server.domain.friend.dto.response.FriendShuffleResponse;
 import com.yello.server.domain.friend.entity.Friend;
@@ -11,17 +13,14 @@ import com.yello.server.domain.user.entity.Social;
 import com.yello.server.domain.user.entity.User;
 import com.yello.server.domain.user.entity.UserRepository;
 import com.yello.server.global.common.util.PaginationUtil;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 
 @SpringBootTest
@@ -68,8 +67,8 @@ class FriendControllerTest {
         friendRepository.save(Friend.createFriend(user, friendB));
 
         List<Friend> friends = friendRepository.findAllFriendsByUserId(pageable, user.getId())
-                .stream()
-                .toList();
+            .stream()
+            .toList();
 
         // then
         assertThat(friends.size()).isEqualTo(2);
@@ -105,8 +104,8 @@ class FriendControllerTest {
 
     private User createNewUser(Long id, String name, String yelloId, Gender gender, School group) {
         return userRepository.save(
-                new User(id, name, yelloId, gender, 0, Social.KAKAO, "profileImageUrl", "uuid", LocalDateTime.now(),
-                        group));
+            new User(id, name, yelloId, gender, 0, Social.KAKAO, "profileImageUrl", "uuid", LocalDateTime.now(),
+                group));
     }
 
     private void createNewFriend(User user, User friend) {


### PR DESCRIPTION
### ☘️ Related Issue
* resolves YEL-19

### ✅ Work description
* 유저 상세 정보 조회 API 구현
* Exception이 기존에 두 개의 파라미터를 필요로 했는데, 클린 코드를 위해 하나의 파라미터로 처리할 수 있도록 변경
* 컨벤션 정립을 위해 커스텀 Response 사용

### 💡 PR point
* 
