### PR TITLE
YEL-145 [fix] soft deleted 유저의 yelloId 중복 체크

### DIFF
--- a/src/main/java/com/yello/server/domain/authorization/service/AuthManagerImpl.java
+++ b/src/main/java/com/yello/server/domain/authorization/service/AuthManagerImpl.java
@@ -71,7 +71,7 @@ public class AuthManagerImpl implements AuthManager {
                 throw new UserConflictException(UUID_CONFLICT_USER_EXCEPTION);
             });
 
-        userRepository.findByYelloId(signUpRequest.yelloId())
+        userRepository.findByYelloIdNotFiltered(signUpRequest.yelloId())
             .ifPresent(action -> {
                 throw new UserConflictException(YELLOID_CONFLICT_USER_EXCEPTION);
             });
@@ -81,7 +81,7 @@ public class AuthManagerImpl implements AuthManager {
     public Boolean renewUserData(User user) {
         final Long userId = user.getId();
 
-        if (user.getDeletedAt()!=null) {
+        if (user.getDeletedAt() != null) {
             user.renew();
 
             friendRepository.findAllByUserIdNotFiltered(userId)

--- a/src/main/java/com/yello/server/domain/authorization/service/AuthService.java
+++ b/src/main/java/com/yello/server/domain/authorization/service/AuthService.java
@@ -80,7 +80,7 @@ public class AuthService {
             throw new AuthBadRequestException(YELLOID_REQUIRED_EXCEPTION);
         }
 
-        return userRepository.findByYelloId(yelloId).isPresent();
+        return userRepository.findByYelloIdNotFiltered(yelloId).isPresent();
     }
 
     @Transactional
@@ -103,7 +103,7 @@ public class AuthService {
 
     @Transactional
     public void recommendUser(String recommendYelloId, String userYelloId) {
-        if (recommendYelloId!=null && !recommendYelloId.isEmpty()) {
+        if (recommendYelloId != null && !recommendYelloId.isEmpty()) {
             User recommendedUser = userRepository.getByYelloId(recommendYelloId);
             User user = userRepository.getByYelloId(userYelloId);
 

--- a/src/main/java/com/yello/server/domain/user/repository/UserJpaRepository.java
+++ b/src/main/java/com/yello/server/domain/user/repository/UserJpaRepository.java
@@ -29,6 +29,10 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
     Optional<User> findByYelloId(@Param("yelloId") String yelloId);
 
     @Query("select u from User u " +
+        "where u.yelloId = :yelloId")
+    Optional<User> findByYelloIdNotFiltered(@Param("yelloId") String yelloId);
+
+    @Query("select u from User u " +
         "where u.group.id = :groupId " +
         "and u.deletedAt is null")
     List<User> findAllByGroupId(@Param("groupId") Long groupId);

--- a/src/main/java/com/yello/server/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/yello/server/domain/user/repository/UserRepository.java
@@ -20,6 +20,8 @@ public interface UserRepository {
 
     Optional<User> findByYelloId(String yelloId);
 
+    Optional<User> findByYelloIdNotFiltered(String yelloId);
+
     User getByYelloId(String yelloId);
 
     Optional<User> findByDeviceToken(String deviceToken);

--- a/src/main/java/com/yello/server/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/yello/server/domain/user/repository/UserRepositoryImpl.java
@@ -58,6 +58,11 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
+    public Optional<User> findByYelloIdNotFiltered(String yelloId) {
+        return userJpaRepository.findByYelloIdNotFiltered(yelloId);
+    }
+
+    @Override
     public User getByYelloId(String yelloId) {
         return userJpaRepository.findByYelloId(yelloId)
             .orElseThrow(() -> new UserNotFoundException(YELLOID_NOT_FOUND_USER_EXCEPTION));

--- a/src/main/java/com/yello/server/global/HealthCheckController.java
+++ b/src/main/java/com/yello/server/global/HealthCheckController.java
@@ -12,4 +12,9 @@ public class HealthCheckController {
     public String healthCheck() {
         return "Yell:o world!";
     }
+
+    @GetMapping("/abc")
+    public void text() throws Exception {
+        throw new Exception("Abc");
+    }
 }

--- a/src/test/java/com/yello/server/domain/authorization/FakeAuthManager.java
+++ b/src/test/java/com/yello/server/domain/authorization/FakeAuthManager.java
@@ -76,7 +76,7 @@ public class FakeAuthManager implements AuthManager {
                 throw new UserConflictException(UUID_CONFLICT_USER_EXCEPTION);
             });
 
-        userRepository.findByYelloId(signUpRequest.yelloId())
+        userRepository.findByYelloIdNotFiltered(signUpRequest.yelloId())
             .ifPresent(action -> {
                 throw new UserConflictException(YELLOID_CONFLICT_USER_EXCEPTION);
             });
@@ -86,7 +86,7 @@ public class FakeAuthManager implements AuthManager {
     public Boolean renewUserData(User user) {
         final Long userId = user.getId();
 
-        if (user.getDeletedAt()!=null) {
+        if (user.getDeletedAt() != null) {
             user.renew();
 
             friendRepository.findAllByUserIdNotFiltered(userId)

--- a/src/test/java/com/yello/server/domain/user/FakeUserRepository.java
+++ b/src/test/java/com/yello/server/domain/user/FakeUserRepository.java
@@ -18,12 +18,12 @@ public class FakeUserRepository implements UserRepository {
 
     @Override
     public User save(User user) {
-        if (user.getId()!=null && user.getId() > id) {
+        if (user.getId() != null && user.getId() > id) {
             id = user.getId();
         }
 
         User newUser = User.builder()
-            .id(user.getId()==null ? ++id : user.getId())
+            .id(user.getId() == null ? ++id : user.getId())
             .recommendCount(0L)
             .name(user.getName())
             .yelloId(user.getYelloId())
@@ -82,6 +82,14 @@ public class FakeUserRepository implements UserRepository {
 
     @Override
     public Optional<User> findByYelloId(String yelloId) {
+        return data.stream()
+            .filter(user -> user.getDeletedAt() == null)
+            .filter(user -> user.getYelloId().equals(yelloId))
+            .findFirst();
+    }
+
+    @Override
+    public Optional<User> findByYelloIdNotFiltered(String yelloId) {
         return data.stream()
             .filter(user -> user.getYelloId().equals(yelloId))
             .findFirst();


### PR DESCRIPTION
### ☘️ Related Issue
* resolves 
YEL-145 [fix] soft deleted 유저의 yelloId 중복 체크
### ✅ Work description
* 

### 💡 PR point
* 
