### PR TITLE
YEL-202 [feat] 그룹정보만 수정할 때 제약 추가하도록 수정

### DIFF
--- a/src/docs/asciidoc/edit-user.adoc
+++ b/src/docs/asciidoc/edit-user.adoc
@@ -30,8 +30,10 @@ include::{snippets}/api/v1/user/update/http-response.adoc[]
 * 해당 정보 수정API는 도메인 별로 만들 예정입니다.
 - 비즈니스 로직인 **'1년에 1회 수정 가능하다'**라는 조건과 상관없이 여러번 호출하여 유저 정보 수정이 가능합니다.
 * 해당 비즈니스 로직을 만족하기 위해서 link:user-data-get.html[프로필 수정 가능 여부 조회]를 같이 사용해주세요.
+** UserGroup(`groupId`, `groupAdmissionYear`)에 대한 정보가 유저의 기존 정보와 달라졌을때**만** `프로필 수정 가능 여부` 가 갱신됩니다.
 
 === CHANGELOG
 
+- 2024.02.02 groupId, groupAdmissionYear 변경에 따른 제약조건 추가
 - 2024.01.31 릴리즈
 - 2024.01.09 명세 작성

--- a/src/main/java/com/yello/server/domain/user/dto/request/UserUpdateRequest.java
+++ b/src/main/java/com/yello/server/domain/user/dto/request/UserUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.yello.server.domain.user.dto.request;
 
+import com.yello.server.domain.user.entity.User;
 import lombok.Builder;
 
 @Builder
@@ -13,4 +14,8 @@ public record UserUpdateRequest(
     Integer groupAdmissionYear
 ) {
 
+    public boolean groupInfoEquals(User user) {
+        return groupId.equals(user.getGroup().getId()) &&
+            groupAdmissionYear.equals(user.getGroupAdmissionYear());
+    }
 }

--- a/src/main/java/com/yello/server/domain/user/service/UserService.java
+++ b/src/main/java/com/yello/server/domain/user/service/UserService.java
@@ -143,20 +143,22 @@ public class UserService {
         final Optional<UserData> userData = userDataRepository.findByUserIdAndTag(userId,
             UserDataType.ACCOUNT_UPDATED_AT);
 
-        if (userData.isPresent()) {
-            userData.get().setValue(
-                ZonedDateTime.now(ConstantUtil.GlobalZoneId).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
-            );
-        } else {
-            userDataRepository.save(UserData.of(
-                ACCOUNT_UPDATED_AT,
-                ZonedDateTime.now(ConstantUtil.GlobalZoneId).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
-                user
-            ));
-        }
-
         // logic
         user.update(request, gender, userGroup);
+
+        if (!request.groupInfoEquals(user)) {
+            if (userData.isPresent()) {
+                userData.get().setValue(
+                    ZonedDateTime.now(ConstantUtil.GlobalZoneId).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                );
+            } else {
+                userDataRepository.save(UserData.of(
+                    ACCOUNT_UPDATED_AT,
+                    ZonedDateTime.now(ConstantUtil.GlobalZoneId).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
+                    user
+                ));
+            }
+        }
     }
 
     public UserDataResponse readUserData(Long userId, UserDataType tag) {

--- a/src/main/resources/static/docs/edit-user.html
+++ b/src/main/resources/static/docs/edit-user.html
@@ -447,7 +447,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <h3 id="_요청">요청</h3>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/user HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/user HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer your-access-token
 Content-Length: 195
@@ -521,7 +521,7 @@ Content-Type: application/json
 
 {
   "status" : 200,
-  "message" : "유저 탈퇴에 성공했습니다."
+  "message" : "유저 상세 정보 수정에 성공하였습니다."
 }</code></pre>
 </div>
 </div>
@@ -549,6 +549,13 @@ Content-Type: application/json
 <ul>
 <li>
 <p>해당 비즈니스 로직을 만족하기 위해서 <a href="user-data-get.html">프로필 수정 가능 여부 조회</a>를 같이 사용해주세요.</p>
+<div class="ulist">
+<ul>
+<li>
+<p>UserGroup(<code>groupId</code>, <code>groupAdmissionYear</code>)에 대한 정보가 유저의 기존 정보와 달라졌을때<strong>만</strong> <code>프로필 수정 가능 여부</code> 가 갱신됩니다.</p>
+</li>
+</ul>
+</div>
 </li>
 </ul>
 </div>
@@ -560,6 +567,9 @@ Content-Type: application/json
 <h3 id="_changelog">CHANGELOG</h3>
 <div class="ulist">
 <ul>
+<li>
+<p>2024.02.02 groupId, groupAdmissionYear 변경에 따른 제약조건 추가</p>
+</li>
 <li>
 <p>2024.01.31 릴리즈</p>
 </li>

--- a/src/main/resources/static/docs/purchase-info.html
+++ b/src/main/resources/static/docs/purchase-info.html
@@ -468,7 +468,7 @@ Content-Type: application/json
   "data" : {
     "id" : 1,
     "subscribe" : "normal",
-    "expiredDate" : "2024-02-07"
+    "expiredDate" : "2024-01-08"
   }
 }</code></pre>
 </div>

--- a/src/test/java/com/yello/server/domain/user/medium/UserControllerTest.java
+++ b/src/test/java/com/yello/server/domain/user/medium/UserControllerTest.java
@@ -36,6 +36,7 @@ import com.yello.server.global.exception.ControllerExceptionAdvice;
 import com.yello.server.util.TestDataEntityUtil;
 import com.yello.server.util.TestDataUtil;
 import com.yello.server.util.WithAccessTokenUser;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -234,9 +235,9 @@ class UserControllerTest {
     @Test
     void 유저_구독_정보_조회에_성공합니다() throws Exception {
         // given
-
+        LocalDateTime now = LocalDateTime.of(2024, 1, 1, 0, 0, 0);
         UserSubscribeDetailResponse userSubscribeDetailResponse =
-            UserSubscribeDetailResponse.of(testDataUtil.generatePurchase(1L, user));
+            UserSubscribeDetailResponse.of(testDataUtil.generatePurchase(1L, user, now));
         // when
         given(userService.getUserSubscribe(anyLong()))
             .willReturn(userSubscribeDetailResponse);

--- a/src/test/java/com/yello/server/domain/user/small/UserServiceTest.java
+++ b/src/test/java/com/yello/server/domain/user/small/UserServiceTest.java
@@ -89,6 +89,7 @@ class UserServiceTest {
             .userDataRepository(userDataRepository)
             .build();
 
+        LocalDateTime now = LocalDateTime.of(2024, 1, 1, 0, 0, 0);
         final UserGroup userGroup = testDataUtil.generateGroup(1L, UserGroupType.UNIVERSITY);
         final UserGroup userGroup2 = testDataUtil.generateGroup(2L, UserGroupType.UNIVERSITY);
         for (int i = 1; i <= 2; i++) {
@@ -96,7 +97,7 @@ class UserServiceTest {
             user.setSubscribe(Subscribe.ACTIVE);
         }
         final User user = userRepository.getById(1L);
-        testDataUtil.generatePurchase(1L, user);
+        testDataUtil.generatePurchase(1L, user, now);
     }
 
     @Test

--- a/src/test/java/com/yello/server/util/TestDataEntityUtil.java
+++ b/src/test/java/com/yello/server/util/TestDataEntityUtil.java
@@ -100,7 +100,7 @@ public class TestDataEntityUtil implements TestDataUtil {
     }
 
     @Override
-    public Purchase generatePurchase(long index, User user) {
+    public Purchase generatePurchase(long index, User user, LocalDateTime createdAt) {
         return Purchase.builder()
             .id(index)
             .gateway(Gateway.APPLE)
@@ -109,8 +109,8 @@ public class TestDataEntityUtil implements TestDataUtil {
             .user(user)
             .transactionId("111")
             .state(PurchaseState.ACTIVE)
-            .createdAt(LocalDateTime.now())
-            .updatedAt(LocalDateTime.now())
+            .createdAt(createdAt)
+            .updatedAt(createdAt)
             .build();
     }
 

--- a/src/test/java/com/yello/server/util/TestDataRepositoryUtil.java
+++ b/src/test/java/com/yello/server/util/TestDataRepositoryUtil.java
@@ -19,6 +19,7 @@ import com.yello.server.domain.user.repository.UserDataRepository;
 import com.yello.server.domain.user.repository.UserRepository;
 import com.yello.server.domain.vote.entity.Vote;
 import com.yello.server.domain.vote.repository.VoteRepository;
+import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 
 public class TestDataRepositoryUtil implements TestDataUtil {
@@ -87,8 +88,8 @@ public class TestDataRepositoryUtil implements TestDataUtil {
     }
 
     @Override
-    public Purchase generatePurchase(long index, User user) {
-        return purchaseRepository.save(testDataEntityUtil.generatePurchase(index, user));
+    public Purchase generatePurchase(long index, User user, LocalDateTime createdAt) {
+        return purchaseRepository.save(testDataEntityUtil.generatePurchase(index, user, createdAt));
     }
 
     @Override

--- a/src/test/java/com/yello/server/util/TestDataUtil.java
+++ b/src/test/java/com/yello/server/util/TestDataUtil.java
@@ -10,6 +10,7 @@ import com.yello.server.domain.question.entity.Question;
 import com.yello.server.domain.question.entity.QuestionGroupType;
 import com.yello.server.domain.user.entity.User;
 import com.yello.server.domain.vote.entity.Vote;
+import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 
 public interface TestDataUtil {
@@ -28,7 +29,7 @@ public interface TestDataUtil {
 
     QuestionGroupType generateQuestionGroupType(long index, Question question);
 
-    Purchase generatePurchase(long index, User user);
+    Purchase generatePurchase(long index, User user, LocalDateTime createdAt);
 
     Notice generateNotice(long index, NoticeType noticeType, ZonedDateTime createdAt);
 }


### PR DESCRIPTION
### ☘️ Related Issue
* resolves 
* [YEL-202 [feat] 그룹정보만 수정할 때 제약 추가하도록 수정](https://github.com/team-yello/YELLO-Server/commit/a986b785a927c292731b36965b35c38f7c37f164)
[YEL-202 [feat] 구독 정보 조회 테스트 빌드시마다 날짜 변경 안되도록 수정](https://github.com/team-yello/YELLO-Server/commit/2b0ec69e653d0fbcb80a4005865d6eda7465061b)
### ✅ Work description
* 

### 💡 PR point
* 
